### PR TITLE
Moving utils.R path from params to input

### DIFF
--- a/workflow/rules/normalize_correct_score.smk
+++ b/workflow/rules/normalize_correct_score.smk
@@ -6,6 +6,7 @@ rule normalize:
         s_phase_genes = get_cell_cycle_s_phase_genes, # for tracking inputs
         g2m_phase_genes = get_cell_cycle_g2m_phase_genes, # for tracking inputs
         module_gene_lists = get_module_gene_lists, # for tracking inputs
+        utils_path = workflow.source_path("../scripts/utils.R"),
     output:
         norm_object = os.path.join(result_path,'{split}','NORMALIZED','object.rds'),
         metadata = report(os.path.join(result_path,'{split}','NORMALIZED','metadata.csv'), 
@@ -36,7 +37,6 @@ rule normalize:
         ab_flag = config["modality_flags"]['Antibody_Capture'],
         crispr_flag = config["modality_flags"]['CRISPR_Guide_Capture'],
         custom_flag = config["modality_flags"]['Custom'],
-        utils_path = workflow.source_path("../scripts/utils.R"),
     script:
         "../scripts/sctransform_cellScore.R"
         
@@ -50,6 +50,7 @@ rule correct:
         s_phase_genes = get_cell_cycle_s_phase_genes,# for tracking inputs
         g2m_phase_genes = get_cell_cycle_g2m_phase_genes,# for tracking inputs
         module_gene_lists = get_module_gene_lists, # for tracking inputs
+        utils_path = workflow.source_path("../scripts/utils.R"),
     output:
         norm_object = os.path.join(result_path,'{split}','CORRECTED','object.rds'),
         metadata = report(os.path.join(result_path,'{split}','CORRECTED','metadata.csv'), 
@@ -80,6 +81,5 @@ rule correct:
         ab_flag = config["modality_flags"]['Antibody_Capture'],
         crispr_flag = config["modality_flags"]['CRISPR_Guide_Capture'],
         custom_flag = config["modality_flags"]['Custom'],
-        utils_path = workflow.source_path("../scripts/utils.R"),
     script:
         "../scripts/sctransform_cellScore.R"

--- a/workflow/rules/visualize.smk
+++ b/workflow/rules/visualize.smk
@@ -3,6 +3,7 @@
 rule metadata_plots:
     input:
         metadata = os.path.join(result_path,'{split}','{step}','metadata.csv'),
+        utils_path = workflow.source_path("../scripts/utils.R"),
     output:
         metadata_plots = report(directory(os.path.join(result_path,'{split}','{step}','plots','metadata')),
                                 patterns=["{datatype}.png"],
@@ -17,8 +18,6 @@ rule metadata_plots:
                                 "feature": "",
                                 }),
         metadata_stats = directory(os.path.join(result_path,'{split}','{step}','stats')),
-    params:
-        utils_path = workflow.source_path("../scripts/utils.R"),
     resources:
         mem_mb=config.get("mem", "16000"),
     threads: config.get("threads", 1)
@@ -34,6 +33,7 @@ rule seurat_plots:
     input:
         norm_object = os.path.join(result_path,'{split}','{step}','object.rds'),
         vis_gene_lists = get_vis_gene_lists, # for tracking inputs
+        utils_path = workflow.source_path("../scripts/utils.R"),
     output:
         plot_dir = report(
             directory(os.path.join(result_path,'{split}','{step}','plots','{plot_type}','{category}','{feature_list}')),
@@ -50,7 +50,6 @@ rule seurat_plots:
             }),
     params:
         vis_gene_lists = config["vis_gene_lists"],
-        utils_path = workflow.source_path("../scripts/utils.R"),
     resources:
         mem_mb=config.get("mem", "16000"),
     threads: config.get("threads", 1)

--- a/workflow/scripts/filter.R
+++ b/workflow/scripts/filter.R
@@ -6,7 +6,7 @@ library("Seurat")
 # source utility functions
 # source("workflow/scripts/utils.R")
 # snakemake@source("./utils.R") # does not work when loaded as module (https://github.com/snakemake/snakemake/issues/2205)
-source(snakemake@params[["utils_path"]])
+source(snakemake@input[["utils_path"]])
 
 # inputs
 raw_object_path <- snakemake@input[["raw_object"]]

--- a/workflow/scripts/merge.R
+++ b/workflow/scripts/merge.R
@@ -4,7 +4,7 @@ library("Seurat")
 # source utility functions
 # source("workflow/scripts/utils.R")
 # snakemake@source("./utils.R") # does not work when loaded as module (https://github.com/snakemake/snakemake/issues/2205)
-source(snakemake@params[["utils_path"]])
+source(snakemake@input[["utils_path"]])
 
 #### configs
 

--- a/workflow/scripts/metadata_plot.R
+++ b/workflow/scripts/metadata_plot.R
@@ -7,7 +7,7 @@ library("ggplot2")
 # source utility functions
 # source("workflow/scripts/utils.R")
 # snakemake@source("./utils.R") # does not work when loaded as module (https://github.com/snakemake/snakemake/issues/2205)
-source(snakemake@params[["utils_path"]])
+source(snakemake@input[["utils_path"]])
 
 # inputs
 metadata_path <- snakemake@input[["metadata"]]

--- a/workflow/scripts/prepare.R
+++ b/workflow/scripts/prepare.R
@@ -5,7 +5,7 @@ library("Seurat")
 # source utility functions
 # source("workflow/scripts/utils.R")
 # snakemake@source("./utils.R") # does not work when loaded as module (https://github.com/snakemake/snakemake/issues/2205)
-source(snakemake@params[["utils_path"]])
+source(snakemake@input[["utils_path"]])
 
 # helper function to assign each cell's gRNA and KO calls
 assign_grna_KO <- function(col) {

--- a/workflow/scripts/pseudobulk.R
+++ b/workflow/scripts/pseudobulk.R
@@ -8,7 +8,7 @@ library("dplyr")
 # source utility functions
 # source("workflow/scripts/utils.R")
 # snakemake@source("./utils.R") # does not work when loaded as module (https://github.com/snakemake/snakemake/issues/2205)
-source(snakemake@params[["utils_path"]])
+source(snakemake@input[["utils_path"]])
 
 # helper function to check if all values in a group are the same
 all_equal <- function(x) {

--- a/workflow/scripts/sctransform_cellScore.R
+++ b/workflow/scripts/sctransform_cellScore.R
@@ -6,7 +6,7 @@ library("sctransform")
 # source utility functions
 # source("workflow/scripts/utils.R")
 # snakemake@source("./utils.R") # does not work when loaded as module (https://github.com/snakemake/snakemake/issues/2205)
-source(snakemake@params[["utils_path"]])
+source(snakemake@input[["utils_path"]])
 
 # Set the future.globals.maxSize option to  90% of allocated memory, converting MB to bytes.
 mem_mb <- as.numeric(snakemake@resources[["mem_mb"]])

--- a/workflow/scripts/seurat_plots.R
+++ b/workflow/scripts/seurat_plots.R
@@ -6,7 +6,7 @@ library("ggplot2")
 # source utility functions
 # source("workflow/scripts/utils.R")
 # snakemake@source("./utils.R") # does not work when loaded as module (https://github.com/snakemake/snakemake/issues/2205)
-source(snakemake@params[["utils_path"]])
+source(snakemake@input[["utils_path"]])
 
 # inputs
 object_path <- snakemake@input[["norm_object"]]

--- a/workflow/scripts/split.R
+++ b/workflow/scripts/split.R
@@ -5,7 +5,7 @@ library("Seurat")
 # source utility functions
 # source("workflow/scripts/utils.R")
 # snakemake@source("./utils.R") # does not work when loaded as module (https://github.com/snakemake/snakemake/issues/2205)
-source(snakemake@params[["utils_path"]])
+source(snakemake@input[["utils_path"]])
 
 # inputs
 merged_object_path <- snakemake@input[["merged_object"]]


### PR DESCRIPTION
During development I encountered problems with steps of the pipeline rerunning due to the cached/temporary path where the utils.R script is located changing in between runs.
Here is part of the console print which demonstrates the changes to the path and why snakemake reran those rules:

——————————————————————
reason: Params have changed since last execution: Union of exclusive params before and now across all output: before: '/nfs/scistore16/itgrp/cjansen/.cache/snakemake/snakemake/source-cache/runtime-cache/tmp_ib_gr2a/file/nfs/scistore16/itgrp/cjansen/Pipelines/scrnaseq_processing_seurat/workflow/rules/../scripts/utils.R' now: '/nfs/scistore16/itgrp/cjansen/.cache/snakemake/snakemake/source-cache/runtime-cache/tmppzt7swv9/file/nfs/scistore16/itgrp/cjansen/Pipelines/scrnaseq_processing_seurat/workflow/rules/../scripts/utils.R’ 
——————————————————————

This is also described in the following issue in the main snakemake repository:
https://github.com/snakemake/snakemake/issues/1805

To fix this I implemented the suggested changes from the issue above, moving the path to the utils.R script from params to input in all of the rules where it was present and of course updating the corresponding source() commands in the associated R scripts.
My guess why this works and `params` doesn't is that `input` is designed to take paths and therefore has additional checks in place to examine wether the input has changed since the last execution. On the other hand `params` is usually used to relay other information such as numbers representing cutoff values etc. therefore it doesn't seem to check for the provided input being a path and if the file behind it actually changed.

I Have tested this on our hardware and it works perfectly fine for me and fixes the issue.

If you have any questions let me know.
All the best, Christian